### PR TITLE
For pull requests, add the target branch repo to the dependencies

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -70,3 +70,10 @@ echo "Gen git snapshot done"
 
 rm *.changes
 echo "$GIT_BRANCH" > branch.buildinfo
+
+# If this is a pull request, we want to also use the target repository for
+# dependency checking. To do so, add the name of the target branch (which is in
+# the CHANGE_TARGET environment variable) to the ubports.depends file.
+if [ -n "${CHANGE_TARGET}" ]; then
+  echo "${CHANGE_TARGET}" >> ubports.depends
+fi


### PR DESCRIPTION
When building a pull request, the name of the target branch tells us
what is the baseline we are targeting.  When fetching dependencies, we
want to make sure that the corresponding repo is enabled.

For example, if a pull request is made against the xenial_-_qt59 branch,
regardless of the branch name used in the user repo we want to fetch the
dependencies from xenial_-_qt59 as well.