### PR TITLE
Enable test and freight multibuild

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -17,7 +17,13 @@ set -ex
 
 export PYTHONIOENCODING=UTF-8
 export BUILD_ONLY=true
-export DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
+
+if [ -f ubports.no_test.buildinfo ]; then
+	export DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
+	rm ubports.no_test.buildinfo
+else
+	export DEB_BUILD_OPTIONS="parallel=$(nproc)"
+fi
 
 if [ -f ubports.depends.buildinfo ]; then
 	mv ubports.depends.buildinfo ubports.depends

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -35,7 +35,6 @@ if [ -f multidist.buildinfo ]; then
     export release="$d"
     export REPOS="$release"
     export WORKSPACE="$rootwp/mbuild/$d"
-    export SHIP_FREIGHT_CACHE=true
     cd "$WORKSPACE"
     mkdir binaries/ || true
     for suffix in gz bz2 xz deb dsc changes ; do
@@ -48,7 +47,6 @@ if [ -f multidist.buildinfo ]; then
     done
     cd $rootwp
 	done
-  sudo freight cache -v -c /etc/freight.conf
 else
   export release=$(cat branch.buildinfo)
   export distribution=$(cat distribution.buildinfo)

--- a/build-source.sh
+++ b/build-source.sh
@@ -98,3 +98,6 @@ fi
 if [ -f source/ubports.depends ]; then
         cp source/ubports.depends ubports.depends.buildinfo
 fi
+if [ -f source/ubports.no_test ]; then
+        cp source/ubports.no_test ubports.no_test.buildinfo
+fi


### PR DESCRIPTION
This enables tests by default, This also adds the option to disable it with creating a dummy file called ubports.no_test.

And it also removed the need to do a full cache after multibuild since we not do per branch freight cache update