### PR TITLE
pbuilder: don't disable unit tests

### DIFF
--- a/pbuilder/pbuilderrc
+++ b/pbuilder/pbuilderrc
@@ -5,9 +5,6 @@
 #
 # read pbuilderrc.5 document for notes on specific options.
 
-DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
-export DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
-
 PYTHONIOENCODING=UTF-8
 LC_CTYPE=en_US.UTF-8
 


### PR DESCRIPTION
We already have a mechanism to disable unit tests via the
`ubports.no_test.buildinfo` file.

As you can see from https://ci.ubports.com/blue/organizations/jenkins/qtorganizer5-eds/detail/PR-9/17/pipeline/26, `DEB_BUILD_OPTIONS` contains the `nocheck` flag, but that is wrong.