### PR TITLE
Archives and provides -dbgsym packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
-String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt'
-String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo'
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
 
 pipeline {
   agent any

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -52,7 +52,7 @@ else
   export distribution=$(cat distribution.buildinfo)
   export REPOS="$release"
   export BASE_PATH="binaries/"
-  for suffix in gz bz2 xz deb dsc changes ; do
+  for suffix in gz bz2 xz deb ddeb dsc changes ; do
     mv *.${suffix} binaries/ || true
   done
 	/usr/bin/build-and-provide-package


### PR DESCRIPTION
This PR make the changes that make -dbgsym packages available. This is done by:
  - Modifying `Jenkinsfile` so that it stash & archive .ddeb files. This will require every repository to update its copy of `Jenkinsfile`. However, this should be non-breaking, so we can do this gradually. In the future, we might want to consider [Jenkins' shared library](https://jenkins.io/doc/book/pipeline/shared-libraries/).
  - Modifying `build-repo.sh` to copy .ddeb files to `binaries/` directory for distribution. This should make -debsym packages available in the repo, but I don't know how the repo software will react.