### PR TITLE
build-source.sh: support multiple upstream tarball

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -39,8 +39,14 @@ export GIT_BRANCH=$BRANCH_NAME
 cd ..
 
 if [ -f source/ubports.source_location ]; then
-  rm $(head -n 2 source/ubports.source_location | tail -1) || true
-  wget -O $(head -n 2 source/ubports.source_location | tail -1) $(head -n 1 source/ubports.source_location)
+  while read -r SOURCE_URL && read -r SOURCE_FILENAME; do
+    if [ -f "$SOURCE_FILENAME" ]; then
+      rm "$SOURCE_FILENAME"
+    fi
+
+    wget -O "$SOURCE_FILENAME" "$SOURCE_URL"
+  done <source/ubports.source_location
+
   export IGNORE_GIT_BUILDPACKAGE=true
   export USE_ORIG_VERSION=true
   export SKIP_DCH=true


### PR DESCRIPTION
build-source.sh will read the ubports.source_location 2 lines at a time,
and stop if no more line is available. This way, the format of the file
is (mostly) preserved. The only change is that, by using shell script's
read command, the ubports.source_location must ends with a newline
charactor.

This is required for building gst-droid, as it requires the tarball for
itself and the tarball for gstreamer's "common" repo.