### PR TITLE
Revert "build-repo.sh: copy .ddeb files to binaries dir"

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -52,7 +52,7 @@ else
   export distribution=$(cat distribution.buildinfo)
   export REPOS="$release"
   export BASE_PATH="binaries/"
-  for suffix in gz bz2 xz deb ddeb dsc changes ; do
+  for suffix in gz bz2 xz deb dsc changes ; do
     mv *.${suffix} binaries/ || true
   done
 	/usr/bin/build-and-provide-package


### PR DESCRIPTION
Seems like Freight doesn't play nice with .ddeb files. This commit seems
to cause build failure on archiving stage with any package which has the
updated Jenkinsfile to archive .ddeb [1]. So, revert this commit for now
until Freight supports .ddeb file.

[1] https://ci.ubports.com/blue/organizations/jenkins/nemo-qtmultimedia-plugins-packaging/detail/xenial_-_gst-droid/1/pipeline/

This reverts commit a6a604e9860c265519fef44d9dbbb9074d4561ab.