### PR TITLE
build-and-provide-package: Look only for the "real" debian/control file

### DIFF
--- a/build-and-provide-package
+++ b/build-and-provide-package
@@ -499,9 +499,9 @@ identify_build_type() {
   local old_dir=$(pwd)
   cd "$TMPDIR"
   for file in  ${BASE_PATH}/${SOURCE_PACKAGE}_*.tar.* ; do
-    if tar atf "$file" 2>/dev/null | egrep -q 'debian/control' ; then
+    if tar atf "$file" 2>/dev/null | egrep -q '^[^/]+/debian/control$' ; then
       # might be source/debian/control - so let's identify the path to debian/control
-      local control_file=$(tar atf "$file" 2>/dev/null | egrep 'debian/control')
+      local control_file=$(tar atf "$file" 2>/dev/null | egrep '^[^/]+/debian/control$')
       tar axf "$file" "$control_file" || bailout 1 "Error while looking at debian/control in source archive."
 
       if grep -q '^Architecture: all' "$control_file" ; then


### PR DESCRIPTION
Otherwise this breaks in a situation like that:

| % tar atf autopkgtest_2.3.5~pgdg70+1.tar.gz | grep control
| -rw-r--r-- 0/0             297 2013-09-25 08:51 source/tests/testpkg/debian/control
| -rw-r--r-- 0/0             151 2013-09-25 08:51 source/debian/tests/control
| -rw-r--r-- 0/0            1982 2013-09-25 08:51 source/debian/control

Thanks: Christoph Berg <christoph.berg@credativ.de> for the bugreport and fix
(cherry picked from commit 5d465bf537f38a083de61d6ff1815c9044cef352)

----------------------------------------------------------------------------------------

This should solve issues with debian.in files such as in gst-plugins-good1.0 [1].

[1] https://ci.ubports.com/blue/organizations/jenkins/gst-plugins-good1.0-packaging/detail/xenial_-_gst-droid/1/pipeline/26