### PR TITLE
build-binary: fix debsigning for multidist case

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -61,11 +61,17 @@ if [ -f multidist.buildinfo ]; then
 		/usr/bin/build-and-provide-package
 		cd $rootwp
 	done
+
+	. /etc/jenkins/debian_glue
+	for d in $MULTI_DIST ; do
+		debsign -k"${KEY_ID:-}" "mbuild/$d/"*.changes
+	done
+
 	tar -zcvf multidist-$architecture-$RANDOM.tar.gz mbuild
 else
 	export distribution=$(cat distribution.buildinfo)
 	/usr/bin/build-and-provide-package
-fi
 
-. /etc/jenkins/debian_glue
-debsign -k"${KEY_ID:-}" *.changes
+	. /etc/jenkins/debian_glue
+	debsign -k"${KEY_ID:-}" *.changes
+fi


### PR DESCRIPTION
Debsign is done at the end of the script, assuming that changes files
are at the root. However, that isn't the case for multidist building,
where packages for each distro are built in its directory.

This commit move the original code to the non-multidist case. Then, in
multidist case, make sure to iterate over all distros and sign changes
files in that directory before archiving them.

---------------------------------------------------------------------------------

See https://ci.ubports.com/blue/organizations/jenkins/timekeeper/detail/master/12/pipeline/ for the failing build.