### PR TITLE
build-and-provide-package: fix debian/control lookup for non-native pkgs

### DIFF
--- a/build-and-provide-package
+++ b/build-and-provide-package
@@ -499,9 +499,10 @@ identify_build_type() {
   local old_dir=$(pwd)
   cd "$TMPDIR"
   for file in  ${BASE_PATH}/${SOURCE_PACKAGE}_*.tar.* ; do
-    if tar atf "$file" 2>/dev/null | egrep -q '^[^/]+/debian/control$' ; then
+    if tar atf "$file" 2>/dev/null | egrep -q '^([^/]+/)?debian/control$' ; then
       # might be source/debian/control - so let's identify the path to debian/control
-      local control_file=$(tar atf "$file" 2>/dev/null | egrep '^[^/]+/debian/control$')
+      # This assumes that no one will put `debian/debian/control` in debian tarball.
+      local control_file=$(tar atf "$file" 2>/dev/null | egrep '^([^/]+/)?debian/control$')
       tar axf "$file" "$control_file" || bailout 1 "Error while looking at debian/control in source archive."
 
       if grep -q '^Architecture: all' "$control_file" ; then


### PR DESCRIPTION
Commit 67094333ddb4f0a7fa559a0c46bef141a842d423 (build-and-provide-
package: Look only for the "real" debian/control file) fixes debian/
control lookup for native packages with multiple debian/control files.
However, it completely breaks the non-native case, as the regex always
expect 1 level of subdirectory.

This commit edit the regex to make the 1 level of subdirectory part
optional. This make it works on both native and non-native packages.

This has been tested on the original offending package (autopkgtest) to
make sure no regression occurs.

----------------------------------------------------------------------------------

This should fix no-binary packages which use `Architecture: all` like `droidmedia`.

https://ci.ubports.com/blue/organizations/jenkins/droidmedia-packaging/detail/xenial_-_gst-droid_-_gst-droid-0.20191129.0/2/pipeline/24

(Search for `.debian.`)