### PR TITLE
Move intelligence around branch and apt repo into build-source.sh

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (C) 2017,2018 Marius Gripsgard <marius@ubports.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -38,7 +40,7 @@ fi
 if [ -f ubports.architecture ]; then
   THIS_ARCH=$(dpkg --print-architecture)
 	REQUEST_ARCH=$(cat ubports.architecture)
-	if [ ! "$THIS_ARCH" == "$REQUEST_ARCH" ]; then
+	if [ ! "$THIS_ARCH" = "$REQUEST_ARCH" ]; then
 		echo "My arch $THIS_ARCH does not match requested arch $REQUEST_ARCH, quiting"
 		exit 0
 	fi

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -37,9 +37,9 @@ if [ -f ubports.repos_extra ]; then
   echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
 fi
 
-if [ -f ubports.architecture ]; then
+if [ -f ubports.architecture.buildinfo ]; then
   THIS_ARCH=$(dpkg --print-architecture)
-	REQUEST_ARCH=$(cat ubports.architecture)
+	REQUEST_ARCH=$(cat ubports.architecture.buildinfo)
 	if [ ! "$THIS_ARCH" = "$REQUEST_ARCH" ]; then
 		echo "My arch $THIS_ARCH does not match requested arch $REQUEST_ARCH, quiting"
 		exit 0

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -63,9 +63,10 @@ if [ -f multidist.buildinfo ]; then
     cd $rootwp
 	done
 else
-  export release=$(cat branch.buildinfo)
-  export distribution=$(cat distribution.buildinfo)
-  export REPOS="$release"
+  release="$(cat ubports.target_apt_repository.buildinfo)"
+  distribution=$(cat distribution.buildinfo)
+  REPOS="$release"
+  export release distribution REPOS
 
   for suffix in gz bz2 xz deb dsc changes ddeb udeb buildinfo ; do
     mv *.${suffix} $BASE_PATH || true

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (C) 2017 Marius Gripsgard <marius@ubports.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/build-source.sh
+++ b/build-source.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (C) 2017 Marius Gripsgard <marius@ubports.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -70,7 +72,7 @@ fi
 
 # Multi dist build for "master" only
 # We might want to expand this to allow PR's to build like this
-if [ "$GIT_BRANCH" == "master" ]; then
+if [ "$GIT_BRANCH" = "master" ]; then
   echo "Doing multi build!"
   for d in $MULTI_DIST ; do
     echo "Gen git snapshot for $d"


### PR DESCRIPTION
- build-source.sh will detect if it's building a PR and then put each PR
  for each git repository in its own apt repository
- For branches within the repo, build-source.sh will strip "ubports/"
  prefix if present. This allows us to share the same repository with
  another distro if appropriate.
- build-source.sh will put repo name in "ubports.target_apt_repository
  .buildinfo" and no longer pass raw branch name.
- Arch extension parsing is moved from generate_repo_extra.py to
  build-source.sh. It puts parsed architecture to "ubports.architecture
  .buildinfo"
- Other scripts are updated to accommodate file name and convention
  changes.

@UniversalSuperBox I decided to leave out baning non-prefixed branches other than the releasing branches. I think that kind of thing should be done in the Jenkins configuration.