### PR TITLE
build-source: use _ to separate words in PR branch

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -97,7 +97,7 @@ fi
 if [ -n "$CHANGE_ID" ]; then
   # This is a PR. Publish each PR for each project into its own repository
   GIT_REPO_NAME="$(basename "${GIT_URL%.git}")"
-  REPOS="PR/${GIT_REPO_NAME}/${CHANGE_ID}"
+  REPOS="PR_${GIT_REPO_NAME}_${CHANGE_ID}"
 
   # We want the target branch to be part of our repo dependency (in addition to
   # what's specified in ubports.depends)


### PR DESCRIPTION
Turns out aptly chokes on having `/` in the repo name and converts it to
`-`, making the rest of the scripts that don't expect it chokes too.

Thus, I decided to change the separator to `_`, the reason being that
there're some (git) repo with `-`, but most repo don't have `_`.