### PR TITLE
build-binary: allow nodoc & other build profiles

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -20,12 +20,35 @@ set -ex
 export PYTHONIOENCODING=UTF-8
 export BUILD_ONLY=true
 
+# Parallel option is overwritten by build-and-provide-package anyway, but in
+# case we switch from it, let's leave it in.
+
+DEB_BUILD_OPTIONS="parallel=$(nproc)"
+DEB_BUILD_PROFILES=""
+
 if [ -f ubports.no_test.buildinfo ]; then
-	export DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
+	DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} nocheck"
+	DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES} nocheck"
+
 	rm ubports.no_test.buildinfo
-else
-	export DEB_BUILD_OPTIONS="parallel=$(nproc)"
 fi
+
+if [ -f ubports.no_doc.buildinfo ]; then
+	DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} nodoc"
+	DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES} nodoc"
+
+	rm ubports.no_doc.buildinfo
+fi
+
+# Allow setting additional build profiles. Useful for bootstraping
+# circular dependencies.
+if [ -f ubports.build_profiles.buildinfo ]; then
+	DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES} $(cat ubports.build_profiles.buildinfo)"
+
+	rm ubports.build_profiles.buildinfo
+fi
+
+export DEB_BUILD_OPTIONS DEB_BUILD_PROFILES
 
 if [ -f ubports.depends.buildinfo ]; then
 	mv ubports.depends.buildinfo ubports.depends

--- a/build-source.sh
+++ b/build-source.sh
@@ -131,6 +131,8 @@ fi
 for file in \
     ubports.depends \
     ubports.no_test \
+    ubports.no_doc \
+    ubports.build_profiles \
     ubports.backports \
   ; do
   if [ -f source/$file ]; then

--- a/build-source.sh
+++ b/build-source.sh
@@ -90,7 +90,7 @@ if [ "$GIT_BRANCH" = "master" ]; then
   echo "$MULTI_DIST" > multidist.buildinfo
 else
   export TIMESTAMP_FORMAT="$d%Y%m%d%H%M%S"
-  /usr/bin/generate-git-snapshot
+  # /usr/bin/generate-git-snapshot
   echo "Gen git snapshot done"
 fi
 
@@ -128,12 +128,12 @@ if [ -n "$REQUEST_ARCH" ]; then
   fi
 fi
 
-if [ -f source/ubports.depends ]; then
-        cp source/ubports.depends ubports.depends.buildinfo
-fi
-if [ -f source/ubports.no_test ]; then
-        cp source/ubports.no_test ubports.no_test.buildinfo
-fi
-if [ -f source/ubports.backports ]; then
-        cp source/ubports.backports ubports.backports.buildinfo
-fi
+for file in \
+    ubports.depends \
+    ubports.no_test \
+    ubports.backports \
+  ; do
+  if [ -f source/$file ]; then
+    cp source/$file $file.buildinfo
+  fi
+done


### PR DESCRIPTION
- Also add `notest` build profile if ubports.no_test is placed.
- Add `nodoc` build options and profiles if ubports.no_doc is placed.
- Allow setting additional build profiles via the content of
  ubports.build_profiles.