### PR TITLE
build-source: fix the path for PR target's ubports.depends

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -117,7 +117,7 @@ if [ -n "$CHANGE_ID" ]; then
 
   if [ -n "${CHANGE_TARGET}" ]; then
     # Remove "ubports/" prefix if present
-    echo "${CHANGE_TARGET#ubports/}" >> source/ubports.depends
+    echo "${CHANGE_TARGET#ubports/}" >> ubports.depends.buildinfo
   fi
 else
   # Support both ubports/xenial(_-_.*)? and xenial(_-_.*)?


### PR DESCRIPTION
I forgot that we update this file during the branch decision process.
We have to update the path.