### PR TITLE
build-source: various cleanups, allow building UNRELEASED version, unify version numbering logic for non-native packages

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -207,11 +207,16 @@ else
   if [ "$changelog_dist" = "UNRELEASED" ]; then
     # generate-git-snapsnot does the right thing for unreleased version. We just want some commit info.
     export UNRELEASED_APPEND_COMMIT=true
-  elif [ -n "$CHANGE_TARGET" ] && (cd source && git diff --stat "${CHANGE_TARGET}..HEAD" | grep -q '^ debian/changelog '); then
-    # A PR is, by definition, prerelease. Tell generate-git-snapshot not to increase version so that when
-    # the released version comes out (which is when this PR gets merged), this version won't trump the release.
-    # generate-git-snapshot will append the timestamp and git commit.
-    export DONT_INCREASE_VERSION=true
+  elif [ -n "$CHANGE_TARGET" ]; then
+    cd source/
+    git fetch origin "${CHANGE_TARGET}"
+    if git diff --stat "origin/${CHANGE_TARGET}..HEAD" | grep -q '^ debian/changelog '; then
+      # A PR is, by definition, prerelease. Tell generate-git-snapshot not to increase version so that when
+      # the released version comes out (which is when this PR gets merged), this version won't trump the release.
+      # generate-git-snapshot will append the timestamp and git commit.
+      export DONT_INCREASE_VERSION=true
+    fi
+    cd ../
   elif (cd source && git show --stat --pretty=format: HEAD|grep -q '^ debian/changelog '); then
     # The last commit touch the changelog; assumes the it's the releasing commit
     if $is_releasing_repo; then

--- a/build-source.sh
+++ b/build-source.sh
@@ -69,6 +69,11 @@ if [ -n "$source_location_file" ]; then
   done <"$source_location_file"
 
   export IGNORE_GIT_BUILDPACKAGE=true
+  # FIXME: This relies on UBports-specific change to generate-git-snapshot.
+  # Maybe using PRE_SOURCE_HOOK, but it accepts shell script file path and
+  # that means we have to locate the path of ourself.
+  export SKIP_PRE_CLEANUP=true
+
   # Always include the original source in the .changes file.
   # Ideally we should do this only when we have a new upstream version, but
   # I'm too lazy to check if a source package is already in the repo.

--- a/build-source.sh
+++ b/build-source.sh
@@ -114,11 +114,15 @@ if [ "$GIT_BRANCH" = "master" ]; then
   for d in $BUILD_DISTS_MULTI ; do
     echo "Gen git snapshot for $d"
     export TIMESTAMP_FORMAT="$d%Y%m%d%H%M%S"
-    export DIST_OVERRIDE="$d"
+    export DIST="$d"
+    # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
+    export DIST_OVERRIDE="$DIST"
     /usr/bin/generate-git-snapshot
     mkdir -p "mbuild/$d"
     mv *+0~$d* "mbuild/$d"
     unset TIMESTAMP_FORMAT
+    unset DIST
+    # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
     unset DIST_OVERRIDE
   done
   tar -zcvf multidist.tar.gz mbuild
@@ -247,6 +251,11 @@ else
       exit 1
     fi
   fi
+
+  # Convey the distribution of choice (used by build-binary.sh).
+  # It was in our custom generate-git-snapshot, but now we bring it out so that
+  # we don't have to rely on hidden modification.
+  echo "$DIST" > distribution.buildinfo
 fi
 
 # Move buildinfos back to the workspace root, so that they'll be stashed.

--- a/build-source.sh
+++ b/build-source.sh
@@ -117,7 +117,7 @@ if [ "$GIT_BRANCH" = "master" ]; then
     export DIST="$d"
     # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
     export DIST_OVERRIDE="$DIST"
-    /usr/bin/generate-git-snapshot
+    generate-git-snapshot
     mkdir -p "mbuild/$d"
     mv *+0~$d* "mbuild/$d"
     unset TIMESTAMP_FORMAT
@@ -231,7 +231,7 @@ else
   fi
 
   export TIMESTAMP_FORMAT="$d%Y%m%d%H%M%S"
-  /usr/bin/generate-git-snapshot
+  generate-git-snapshot
   echo "Gen git snapshot done"
 
   echo "$REPOS" >buildinfos/ubports.target_apt_repository.buildinfo

--- a/build-source.sh
+++ b/build-source.sh
@@ -206,12 +206,6 @@ else
 
   # Versioning decision override for PR and releasing branch
   if [ "$changelog_dist" = "UNRELEASED" ]; then
-    # If the repo we're publishing is the distro name by itself, we don't allow UNRELEASED change.
-    if $is_releasing_repo; then
-      echo "ERROR: trying to publish UNRELEASD version to a releasing repo \"${REPOS}\"."
-      exit 1
-    fi
-
     # Make sure non-PR unreleased looks like PR unreleased. See below.
     (cd source && debchange --newversion "${changelog_version}~prerelease" --force-bad-version -- "")
   elif [ -n "$CHANGE_TARGET" ] && (cd source && git diff --stat "${CHANGE_TARGET}..HEAD" | grep -q '^ debian/changelog '); then


### PR DESCRIPTION
This PR do various cleanups and change logic related to building imported packages. This makes _every_ package to use the same versioning logic, no matter the package is imported or not, and no matter the repo changes changelog before or after release (or not at all).

First, the script is changed to use the distribution from the branch name rather than the changelog. This allows building commits that have `UNRELEASED` as the distro. This means packages can opt to do the traditional Debian packaging, where the new changelog entry is created right after the previous version is released.

Then, when we have PR where a version is released, we would prefer not to have the actual release version in the PR repo. This is to allow amending the PR, have the amended version built into the PR repo, and still use the same version number when merged. Thus, this PR changes the versioning logic to be the following:

- if distro = UNRELEASED -> do nothing, JDG does the right thing by default.
- else if an MR & touch changelog -> `DONT_INCREASE_VERSION`
- else if the last commit touch changelog
  - releasing branch -> set SKIP_DCH=true. Now the release version is actually released on the repo.
  - else -> `DONT_INCREASE_VERSION`
- else -> do nothing for normal gbp-dch's snapshot versioning.

(releasing branch = xenial, bionic, focal etc.)

Finally, I removed one dependency on our customization of `generate-git-snapshot`. This moves us one step closer to being able to reproduce our CI infrastructure from this repo.

Note that the "multidist" mode is not touched at all. This is due to my lack of understanding of how the mode works.

BTW, I wonder what prevents using "-" in the version? Is the old version of the script (which script) chokes when seeing in in native package? Or it's something else?