### PR TITLE
Add a 'channels-stable' list for stable promotion

### DIFF
--- a/channels-stable.list
+++ b/channels-stable.list
@@ -1,0 +1,3 @@
+ubports-touch/16.04/rc => ubports-touch/16.04/stable
+16.04/arm64/hybris/rc => 16.04/arm64/hybris/stable
+16.04/armhf/hybris/rc => 16.04/armhf/hybris/stable


### PR DESCRIPTION
We use promote-images.py to promote from RC to Stable, just like we do
from Devel to RC.

However, the PinePhone and PineTab in the mainline channel do not take
part in the standard OTA proceedings and should be exempt from that
promotion.