### PR TITLE
BaPDP: do checkout in subdirectory, the correct way

### DIFF
--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -7,13 +7,13 @@ def call(Boolean isArchIndependent = false) {
     options {
       // Only 'Build source' stage requires checkout.
       skipDefaultCheckout()
-      // Uses this together with SKIP_MOVE=true
-      checkoutToSubdirectory('source')
     }
     stages {
       stage('Build source') {
         steps {
-          checkout scm
+          dir('source') {
+            checkout scm
+          }
           sh 'SKIP_MOVE=true /usr/bin/build-source.sh'
           stash(name: 'source', includes: stashFileList)
           cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)


### PR DESCRIPTION
checkoutToSubdirectory() only affects default checkout, which I
explicitly skipped. Instead, I need to use dir() block to checkout in
a subdirectory.

I should have tested the final script before letting PR merge. 🤦
(But at least now I don't have to change multiple repositories.)