### PR TITLE
build-source: fix aptly failure due to orig tarball not in .changes

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -57,6 +57,13 @@ if [ -f source/ubports.source_location ]; then
   export SKIP_DCH=true
   export SKIP_PRE_CLEANUP=true
   export SKIP_GIT_CLEANUP=true
+  # Always include the original source in the .changes file.
+  # Ideally we should do this only when we have a new upstream version, but
+  # I'm too lazy to check if a source package is already in the repo.
+  # This is primarily to please Aptly, and Aptly seems to check for file
+  # duplication anyway. (see dpkg-genchanges manpage)
+  export DBP_EXTRA_OPTS="-sa"
+
   rm source/Jenkinsfile || true
   rm source/ubports.source_location || true
 fi


### PR DESCRIPTION
Aptly cares about including original source tarball in the repo. To be
imported properly, the .orig.tar.* file has to be present in the
.changes the first time the package is imported. But I'm too lazy to
find if this is the first time, so I just tell it to always include the
.orig.tar.* file(s). Aptly seems to check for file duplication anyway.

(See https://ci.ubports.com/blue/organizations/jenkins/ubports%2Fgst-droid-packaging/detail/xenial_-_gst-droid/11)