### PR TITLE
Always clean up after repo step

### DIFF
--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -18,7 +18,11 @@ def call(Boolean isArchIndependent = false) {
           }
           sh 'SKIP_MOVE=true /usr/bin/build-source.sh'
           stash(name: 'source', includes: stashFileList)
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+        }
+        post {
+          cleanup {
+            deleteDir() /* clean up our workspace */
+          }
         }
       }
       stage('Build binaries') {
@@ -30,7 +34,11 @@ def call(Boolean isArchIndependent = false) {
               unstash 'source'
               sh 'architecture="armhf" build-binary.sh'
               stash(includes: stashFileList, name: 'build-armhf')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+            post {
+              cleanup {
+                deleteDir() /* clean up our workspace */
+              }
             }
           }
           stage('Build binary - arm64') {
@@ -40,7 +48,11 @@ def call(Boolean isArchIndependent = false) {
               unstash 'source'
               sh 'architecture="arm64" build-binary.sh'
               stash(includes: stashFileList, name: 'build-arm64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+            post {
+              cleanup {
+                deleteDir() /* clean up our workspace */
+              }
             }
           }
           stage('Build binary - amd64') {
@@ -50,7 +62,11 @@ def call(Boolean isArchIndependent = false) {
               unstash 'source'
               sh 'architecture="amd64" build-binary.sh'
               stash(includes: stashFileList, name: 'build-amd64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+            post {
+              cleanup {
+                deleteDir() /* clean up our workspace */
+              }
             }
           }
         }
@@ -69,11 +85,10 @@ def call(Boolean isArchIndependent = false) {
           archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
           sh '''/usr/bin/build-repo.sh'''
         }
-      }
-      stage('Cleanup') {
-        agent { label 'amd64' }
-        steps {
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+        post {
+          cleanup {
+            deleteDir() /* clean up our workspace */
+          }
         }
       }
     }


### PR DESCRIPTION
`cleanWs()` as a step won't run if any previous steps fail. To make sure we always clean ourselves up, use the `post {}` block instead.

Alternative to https://github.com/ubports/build-tools/pull/53