### PR TITLE
build-binary: move repo_extra code into non-multidist mode

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -50,16 +50,6 @@ fi
 
 export DEB_BUILD_OPTIONS DEB_BUILD_PROFILES
 
-if [ -f ubports.depends.buildinfo ]; then
-	mv ubports.depends.buildinfo ubports.depends
-fi
-generate_repo_extra.py
-if [ -f ubports.repos_extra ]; then
-  export REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
-  export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
-  echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
-fi
-
 if [ -f ubports.architecture.buildinfo ]; then
   THIS_ARCH=$(dpkg --print-architecture)
 	REQUEST_ARCH=$(cat ubports.architecture.buildinfo)
@@ -94,6 +84,16 @@ if [ -f multidist.buildinfo ]; then
 
 	tar -zcvf multidist-$architecture-$RANDOM.tar.gz mbuild
 else
+	if [ -f ubports.depends.buildinfo ]; then
+		mv ubports.depends.buildinfo ubports.depends
+	fi
+	generate_repo_extra.py
+	if [ -f ubports.repos_extra ]; then
+		export REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
+		export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+		echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
+	fi
+
 	export distribution=$(cat distribution.buildinfo)
 	/usr/bin/build-and-provide-package
 

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -70,6 +70,7 @@ if [ -f multidist.buildinfo ]; then
 		echo "Bulding for $d"
 		export distribution=$d
 		export REPOSITORY_EXTRA="deb http://repo.ubports.com/ $d main"
+		export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
 		export WORKSPACE="$rootwp/mbuild/$d"
 		cd "$WORKSPACE"
 		rm -r adt *.gpg || true


### PR DESCRIPTION
generate_repo_extra.py relies on knowing target apt repository. We don't
have that in multidist mode, so it fails, which fails the build.

Thus, move the code into non-multidist mode only. It doesn't make much
sense to be able to depends on additional repos for multidist anyway.

Also set repository extra keys in the multidist case.