### PR TITLE
Support multidist building for PRs & MRs against main/master

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -81,6 +81,9 @@ if [ -f multidist.buildinfo ]; then
 			echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
 		fi
 
+		# Ensure orig tarball exists
+		find "$rootwp" -name '*.orig.*' -exec ln -s '{}' ./ \+
+
 		/usr/bin/build-and-provide-package
 		cd $rootwp
 	done

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -69,21 +69,18 @@ if [ -f multidist.buildinfo ]; then
 	for d in $MULTI_DIST ; do
 		echo "Bulding for $d"
 		export distribution=$d
-
-		case "$d" in
-			xenial|bionic)
-				REPOSITORY_EXTRA="deb http://repo.ubports.com/ $d main"
-				;;
-			*)
-				REPOSITORY_EXTRA="deb http://repo2.ubports.com/ $d main"
-				;;
-		esac
-		export REPOSITORY_EXTRA
-
-		export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
 		export WORKSPACE="$rootwp/mbuild/$d"
 		cd "$WORKSPACE"
 		rm -r adt *.gpg || true
+
+		# generate_repo_extra.py has to run inside the workspace dir
+		generate_repo_extra.py
+		if [ -f ubports.repos_extra ]; then
+			export REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
+			export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+			echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
+		fi
+
 		/usr/bin/build-and-provide-package
 		cd $rootwp
 	done

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -37,11 +37,14 @@ if [ -f multidist.buildinfo ]; then
 
 	for d in $MULTI_DIST ; do
 		echo "Repo-ing for $d"
-		export distribution="$d"
-    export release="$d"
-    export REPOS="$release"
     export WORKSPACE="$rootwp/mbuild/$d"
     cd "$WORKSPACE"
+
+    release="$(cat ubports.target_apt_repository.buildinfo)"
+    distribution=$d
+    REPOS="$release"
+    export release distribution REPOS
+
     mkdir $BASE_PATH || true
     for suffix in gz bz2 xz deb dsc changes ddeb udeb buildinfo ; do
       mv *.${suffix} $BASE_PATH || true

--- a/build-source.sh
+++ b/build-source.sh
@@ -39,7 +39,11 @@ contains() {
 
 # Multi distro, set here to build master for multripple distros!
 MULTIDIST_BRANCHES="main master"
-BUILD_DISTS_MULTI="xenial focal"
+# Contains the distribution name and versioning suffix
+BUILD_DISTS_MULTI="\
+xenial ubports16.04
+focal ubports20.04
+"
 
 VALID_DISTS_UBUNTU="xenial bionic focal groovy"
 VALID_DISTS_DEBIAN="buster bullseye sid"
@@ -123,22 +127,22 @@ export SKIP_GIT_CLEANUP=true
 # We might want to expand this to allow PR's to build like this
 if contains "$MULTIDIST_BRANCHES" "$GIT_BRANCH"; then
   echo "Doing multi build!"
-  for d in $BUILD_DISTS_MULTI ; do
+  while read -r d dist_suffix ; do
     echo "Gen git snapshot for $d"
-    export TIMESTAMP_FORMAT="$d%Y%m%d%H%M%S"
     export DIST="$d"
     # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
     export DIST_OVERRIDE="$DIST"
+    # This will be appended to the version number, after a '+'.
+    export distribution=$dist_suffix
     generate-git-snapshot
     mkdir -p "mbuild/$d"
-    mv *+0~$d* "mbuild/$d"
-    unset TIMESTAMP_FORMAT
+    mv ./*+"${dist_suffix}"* "mbuild/$d"
     unset DIST
     # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
     unset DIST_OVERRIDE
-  done
+  done < <(printf '%s' "$BUILD_DISTS_MULTI")
   tar -zcvf multidist.tar.gz mbuild
-  echo "$BUILD_DISTS_MULTI" > multidist.buildinfo
+  echo "$BUILD_DISTS_MULTI"|cut -d' ' -f1 > multidist.buildinfo
 else
   if [ -n "$CHANGE_ID" ]; then
     # This is a PR. Publish each PR for each project into its own repository

--- a/build-source.sh
+++ b/build-source.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (C) 2017 Marius Gripsgard <marius@ubports.com>
 #
@@ -31,7 +31,14 @@ sourcedebian_or_source () {
   first_existing_file "source/debian/${1}" "source/${1}"
 }
 
+# https://stackoverflow.com/a/8063398
+# Usage: contains aList anItem
+contains() {
+    [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && return 0 || return 1
+}
+
 # Multi distro, set here to build master for multripple distros!
+MULTIDIST_BRANCHES="main master"
 BUILD_DISTS_MULTI="xenial focal"
 
 VALID_DISTS_UBUNTU="xenial bionic focal groovy"
@@ -114,7 +121,7 @@ export SKIP_GIT_CLEANUP=true
 
 # Multi dist build for "master" only
 # We might want to expand this to allow PR's to build like this
-if [ "$GIT_BRANCH" = "master" ]; then
+if contains "$MULTIDIST_BRANCHES" "$GIT_BRANCH"; then
   echo "Doing multi build!"
   for d in $BUILD_DISTS_MULTI ; do
     echo "Gen git snapshot for $d"

--- a/build-source.sh
+++ b/build-source.sh
@@ -127,7 +127,21 @@ export SKIP_GIT_CLEANUP=true
 # We might want to expand this to allow PR's to build like this
 if contains "$MULTIDIST_BRANCHES" "$GIT_BRANCH"; then
   echo "Doing multi build!"
+  # Pre-fetch git branches from the remote, so that we can check if the
+  # branches exist without hitting rate limit (see below).
+  (cd source && git fetch origin) || true
   while read -r d dist_suffix ; do
+    # Check if the distro-specific branch exists.
+    if (cd source && { \
+        git show-branch "remotes/origin/ubports/$d" || \
+        git show-branch "remotes/origin/$d" ;
+    }); then
+      echo "Branch ubports/$d exists, skip multidist build for $d"
+      continue
+    else
+      built_distro="${built_distro} ${d}"
+    fi
+
     echo "Gen git snapshot for $d"
     export DIST="$d"
     # FIXME: remove this when we stop using our custom version of `generate-git-snapshot`
@@ -142,7 +156,14 @@ if contains "$MULTIDIST_BRANCHES" "$GIT_BRANCH"; then
     unset DIST_OVERRIDE
   done < <(printf '%s' "$BUILD_DISTS_MULTI")
   tar -zcvf multidist.tar.gz mbuild
-  echo "$BUILD_DISTS_MULTI"|cut -d' ' -f1 > multidist.buildinfo
+
+  if [ -z "$built_distro" ]; then
+    echo "No distro is included in multidist. Maybe \"$GIT_BRANCH\" shouldn't exist?"
+    exit 1
+  fi
+
+  # "# " removes leading space from $built_distro.
+  echo "${built_distro# }" > multidist.buildinfo
 else
   if [ -n "$CHANGE_ID" ]; then
     # This is a PR. Publish each PR for each project into its own repository


### PR DESCRIPTION
This PR adds support for building PRs & MRs as multidist, which will enable us to actually accepting PRs & MRs against master and let people testing it. This PR also adds a guard preventing the code in master branch from building for xenial, if the branch for it exists.

(Unfortunately we don't support Launchpad's MPs yet. Anyone? Just kidding.)