### PR TITLE
build-source: add ubports/latest branch to be build multidist

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -47,7 +47,7 @@ pr_repo_naming() {
 }
 
 # Multi distro, set here to build master for multripple distros!
-MULTIDIST_BRANCHES="main master"
+MULTIDIST_BRANCHES="main master ubports/latest"
 # Contains the distribution name and versioning suffix
 BUILD_DISTS_MULTI="\
 xenial ubports16.04


### PR DESCRIPTION
`ubports/latest` is an analogus to `debian/latest` in DEP-14 [1]. It
should be used when we're importing the packaging repository from Debian
or Ubuntu, and the branch `master` or `main` is already used by those
distros.

[1] https://dep-team.pages.debian.net/deps/dep14/