### PR TITLE
Linting shell scripts with shellcheck

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (C) 2017,2018 Marius Gripsgard <marius@ubports.com>
 #
@@ -64,7 +64,8 @@ if [ -f multidist.buildinfo ]; then
 	MULTI_DIST=$(cat multidist.buildinfo)
 	tar -xvzf multidist.tar.gz
 	rm multidist.tar.gz
-	export rootwp=$(pwd)
+	rootwp=$(pwd)
+	export rootwp
 
 	# Move orig to mbuild folder
 	find "$rootwp" \
@@ -76,13 +77,15 @@ if [ -f multidist.buildinfo ]; then
 		export distribution=$d
 		export WORKSPACE="$rootwp/mbuild/$d"
 		cd "$WORKSPACE"
-		rm -r adt *.gpg || true
+		rm -r adt ./*.gpg || true
 
 		# generate_repo_extra.py has to run inside the workspace dir
 		generate_repo_extra.py
 		if [ -f ubports.repos_extra ]; then
-			export REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
-			export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+			REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
+			export REPOSITORY_EXTRA
+			REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+			export REPOSITORY_EXTRA_KEYS
 			echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
 		fi
 
@@ -92,7 +95,7 @@ if [ -f multidist.buildinfo ]; then
 			-exec ln -s '{}' ./ ';'
 
 		/usr/bin/build-and-provide-package
-		cd $rootwp
+		cd "$rootwp"
 	done
 
 	. /etc/jenkins/debian_glue
@@ -100,21 +103,24 @@ if [ -f multidist.buildinfo ]; then
 		debsign -k"${KEY_ID:-}" "mbuild/$d/"*.changes
 	done
 
-	tar -zcvf multidist-$architecture-$RANDOM.tar.gz mbuild
+	tar -zcvf "multidist-$architecture-$RANDOM.tar.gz" mbuild
 else
 	if [ -f ubports.depends.buildinfo ]; then
 		mv ubports.depends.buildinfo ubports.depends
 	fi
 	generate_repo_extra.py
 	if [ -f ubports.repos_extra ]; then
-		export REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
-		export REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+		REPOSITORY_EXTRA="$(cat ubports.repos_extra)"
+		export REPOSITORY_EXTRA
+		REPOSITORY_EXTRA_KEYS="https://repo.ubports.com/keyring.gpg"
+		export REPOSITORY_EXTRA_KEYS
 		echo "INFO: Adding extra repo $REPOSITORY_EXTRA"
 	fi
 
-	export distribution=$(cat distribution.buildinfo)
+	distribution=$(cat distribution.buildinfo)
+	export distribution
 	/usr/bin/build-and-provide-package
 
 	. /etc/jenkins/debian_glue
-	debsign -k"${KEY_ID:-}" *.changes
+	debsign -k"${KEY_ID:-}" ./*.changes
 fi

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -29,10 +29,11 @@ if [ -f multidist.buildinfo ]; then
   echo "Doing multibuild"
   MULTI_DIST=$(cat multidist.buildinfo)
   for t in multidist*.tar.gz ; do
-    tar --overwrite -xvzf $t
+    tar --overwrite -xvzf "$t"
   done
   rm multidist*.tar.gz || true
-  export rootwp=$(pwd)
+  rootwp=$(pwd)
+  export rootwp
 
   for d in $MULTI_DIST ; do
     echo "Repo-ing for $d"
@@ -44,12 +45,12 @@ if [ -f multidist.buildinfo ]; then
     REPOS="$release"
     export release distribution REPOS
 
-    if ! aptly -db-open-attempts=400 repo show $release ; then
-      aptly -db-open-attempts=400 repo create -distribution="$release" $release
+    if ! aptly -db-open-attempts=400 repo show "$release" ; then
+      aptly -db-open-attempts=400 repo create -distribution="$release" "$release"
       aptly -db-open-attempts=400 publish repo -origin='UBports' "$release" filesystem:repo:main
     fi
     aptly -db-open-attempts=400 repo include -no-remove-files -repo="$release" .
-    aptly -db-open-attempts=400 publish update $release filesystem:repo:main
+    aptly -db-open-attempts=400 publish update "$release" filesystem:repo:main
 
     if [[ $release =~ ^xenial($|_-_) ]]; then
       # Freight is unable to handle .{d,u}deb files, so ignore those
@@ -58,7 +59,7 @@ if [ -f multidist.buildinfo ]; then
       # for aptly since we use .changes
       mkdir $BASE_PATH || true
       for suffix in gz bz2 xz deb dsc changes buildinfo ; do
-          mv *.${suffix} $BASE_PATH || true
+          mv ./*.${suffix} $BASE_PATH || true
       done
       # Make a copy of the orig since we moved the files making the symlink invalid
       cp "../*.orig.*" $BASE_PATH || true
@@ -66,7 +67,7 @@ if [ -f multidist.buildinfo ]; then
       /usr/bin/build-and-provide-package
     fi
 
-    cd $rootwp
+    cd "$rootwp"
 	done
 else
   release="$(cat ubports.target_apt_repository.buildinfo)"
@@ -75,15 +76,15 @@ else
   export release distribution REPOS
 
   # Publish built packages to Aptly repo.
-  if ! aptly -db-open-attempts=400 repo show $release ; then
-    aptly -db-open-attempts=400 repo create -distribution="$release" $release
+  if ! aptly -db-open-attempts=400 repo show "$release" ; then
+    aptly -db-open-attempts=400 repo create -distribution="$release" "$release"
     aptly -db-open-attempts=400 publish repo -origin='UBports' "$release" filesystem:repo:main
   fi
 
   # -no-remove-files leaves the files on the disk, so that we can also publish
   # them to Freight repo.
   aptly -db-open-attempts=400 repo include -no-remove-files -repo="$release" .
-  aptly -db-open-attempts=400 publish update -force-overwrite $release filesystem:repo:main
+  aptly -db-open-attempts=400 publish update -force-overwrite "$release" filesystem:repo:main
 
   # Todo remove once xenial is gone
   if [[ $release =~ ^xenial($|_-_) ]]; then
@@ -92,7 +93,7 @@ else
     # and to make sure freight only pics up the right files, but not needed
     # for aptly since we use .changes
     for suffix in gz bz2 xz deb dsc changes buildinfo ; do
-      mv *.${suffix} $BASE_PATH || true
+      mv ./*.${suffix} $BASE_PATH || true
     done
 
     /usr/bin/build-and-provide-package

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -84,7 +84,7 @@ else
   # -no-remove-files leaves the files on the disk, so that we can also publish
   # them to Freight repo.
   aptly -db-open-attempts=400 repo include -no-remove-files -repo="$release" .
-  aptly -db-open-attempts=400 publish update -force-overwrite "$release" filesystem:repo:main
+  aptly -db-open-attempts=400 publish update "$release" filesystem:repo:main
 
   # Todo remove once xenial is gone
   if [[ $release =~ ^xenial($|_-_) ]]; then

--- a/build-source.sh
+++ b/build-source.sh
@@ -62,8 +62,8 @@ VALID_ARCHS="armhf arm64 amd64"
 
 if [ ! "$SKIP_MOVE" = "true" ]; then
         tmp=$(mktemp -d)
-        mv * .* $tmp/
-        mv $tmp ./source
+        mv ./* ./.* "$tmp/"
+        mv "$tmp" ./source
 fi
 
 ls source
@@ -74,8 +74,9 @@ cd source
 if [ -f .gitmodules ]; then
   git submodule update --init --recursive
 fi
-export GIT_COMMIT=$(git rev-parse HEAD)
-export GIT_BRANCH=$BRANCH_NAME
+GIT_COMMIT=$(git rev-parse HEAD)
+export GIT_COMMIT
+export GIT_BRANCH="$BRANCH_NAME"
 cd ..
 
 source_location_file=$(sourcedebian_or_source ubports.source_location)


### PR DESCRIPTION
I've used shellcheck to lint our build scripts, taking care not to change the meaning of any of the commands.

This also removes -force-overwrite from the aptly command. This will cause problems with publishing updates at some point in the future I'm sure, but it will also prevent much harder-to-debug problems arising from two different repos having the same named file.