### PR TITLE
build-source: Add support for debian/watch and depricate ubports.source_location

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -86,7 +86,7 @@ fi
 
 source_location_file=$(sourcedebian_or_source ubports.source_location)
 if [ -n "$source_location_file" ]; then
-  echo "WARNING: ubports.source_location file is depricated, please use debian/watch file"
+  echo "WARNING: ubports.source_location file is deprecated, please use debian/watch file"
   while read -r SOURCE_URL && read -r SOURCE_FILENAME; do
     if [ -f "$SOURCE_FILENAME" ]; then
       rm "$SOURCE_FILENAME"

--- a/build-source.sh
+++ b/build-source.sh
@@ -79,8 +79,14 @@ export GIT_COMMIT
 export GIT_BRANCH="$BRANCH_NAME"
 cd ..
 
+source_format=$(cat source/debian/source/format)
+if [[ $source_format != 3.0* ]]; then
+   echo "WARNING: Please upgrade debian source format to 3.0"
+fi
+
 source_location_file=$(sourcedebian_or_source ubports.source_location)
 if [ -n "$source_location_file" ]; then
+  echo "WARNING: ubports.source_location file is depricated, please use debian/watch file"
   while read -r SOURCE_URL && read -r SOURCE_FILENAME; do
     if [ -f "$SOURCE_FILENAME" ]; then
       rm "$SOURCE_FILENAME"
@@ -88,7 +94,15 @@ if [ -n "$source_location_file" ]; then
 
     wget -O "$SOURCE_FILENAME" "$SOURCE_URL"
   done <"$source_location_file"
+  is_quilt=1;
+elif [[ $source_format == "3.0 (quilt)" ]]; then
+  cd source
+  uscan --noconf --force-download --rename --download-current-version --destdir=..
+  cd ..
+  is_quilt=1;
+fi
 
+if [ -n "$is_quilt" ]; then
   export IGNORE_GIT_BUILDPACKAGE=true
   # FIXME: This relies on UBports-specific change to generate-git-snapshot.
   # Maybe using PRE_SOURCE_HOOK, but it accepts shell script file path and


### PR DESCRIPTION
This adds support for using debian/watch files as the method to download
sources. This is a better way as it will automatically find and download
the version defined by changelog. This is also the official debian way
of doing this, this simplifies our merge with salsa debian folders. This
also adds support for checking for newer upstream versions if needed.

This also prints a deprecation warning when using source format lower
then 3.0 and when using ubports.source_location