### PR TITLE
Notify all devices at the end of phasing

### DIFF
--- a/phaser.py
+++ b/phaser.py
@@ -113,7 +113,7 @@ def checkGithubLabel(label):
 
 def sendBroadcastPushNotification(device, channel, version):
     print(
-        ("At the end of phasing: Sending broadcast push notification for device '{}' on channel "
+        ("Sending broadcast push notification for device '{}' on channel "
          "'{}' and version '{}'").format(
             device,
             channel,
@@ -207,8 +207,6 @@ for channel, devices in devices_in_channels.items():
         phase_ver = getPhaseVersionForTag(index, args.tag)
         if not phase_ver:
             print("Did not find phase for {} in {}".format(device, channel))
-            #version = getVersionForTag(index, args.tag)
-            #sendBroadcastPushNotification(device, channel, version)
             continue
 
         phase = phase_ver["phase"]

--- a/phaser.py
+++ b/phaser.py
@@ -111,14 +111,13 @@ def checkGithubLabel(label):
 
     return blocker
 
-def sendBroadcastPushNotification(device, channel, version):
+def sendBroadcastPushNotification(device, channel, version, expiresTime):
     print(
         ("Sending broadcast push notification for device '{}' on channel "
          "'{}' and version '{}'").format(
             device,
             channel,
             version))
-    expiresTime = datetime.datetime.utcnow() + datetime.timedelta(days=30)
     identifier = "{}/{}".format(channel, device)
     pushData = {
         "channel": "system",
@@ -243,4 +242,9 @@ for channel, devices in devices_in_channels.items():
                 print("Error during execution of copy-image, result might be broken!")
                 sys.exit(result.returncode)
             if to_phase % 10  == 0:
-                sendBroadcastPushNotification(device, channel, version)
+                expiresTime = datetime.datetime.utcnow()
+                if to_phase == 100:
+                    expiresTime = expiresTime + datetime.timedelta(hours=10)
+                else:
+                    expiresTime = expiresTime + datetime.timedelta(days=30)
+                sendBroadcastPushNotification(device, channel, version, expiresTime)


### PR DESCRIPTION
We must try to encourage our users to update their devices (also those who do not follow the news), and also to end the uncertainty "When does my OTA arrive". So first shot in the dark, use the broadcast notify at the end of each device´s phase to send out a one-time push with 30 days of lifetime.

This could also be done after every phase increment t.b.h. - the code makes sure that the push is only shown when either the OTA is ready for download or was already downloaded.
