### PR TITLE
build-binary: fix finding multiple orig tarballs

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -67,9 +67,10 @@ if [ -f multidist.buildinfo ]; then
 	rootwp=$(pwd)
 	export rootwp
 
-	# Move orig to mbuild folder
+	# Links orig to mbuild folder
 	find "$rootwp" \
-        -maxdepth 1 -type f -name '*.orig.*' \
+        -maxdepth 1 -type f \
+		'(' -name '*.orig.*' -o -name '*.orig-*.*' ')' \
         -exec mv '{}' "$rootwp/mbuild" ';'
 
 	for d in $MULTI_DIST ; do


### PR DESCRIPTION
Turns out, I forgot that the format for additional orig tarball is
`.orig-<part name>.tar.*`, not `.orig.<part name>.tar.*`. Thus, the
find rule doesn't work.

This commit fixes the find rule so that it correctly includes the part
tarball as well.

While we're at it, fix the comment too.

(Failure: https://ci.ubports.com/blue/organizations/jenkins/UBportsCore%2FPackaging%20%252F%20usb-moded/detail/MR-1/1/pipeline/)