### PR TITLE
build-binary: fix finding multiple orig tarballs, part 2

### DIFF
--- a/build-binary.sh
+++ b/build-binary.sh
@@ -67,7 +67,7 @@ if [ -f multidist.buildinfo ]; then
 	rootwp=$(pwd)
 	export rootwp
 
-	# Links orig to mbuild folder
+	# Moves orig to mbuild folder
 	find "$rootwp" \
         -maxdepth 1 -type f \
 		'(' -name '*.orig.*' -o -name '*.orig-*.*' ')' \
@@ -92,7 +92,8 @@ if [ -f multidist.buildinfo ]; then
 
 		# Ensure orig tarball exists
 		find ../ \
-			-maxdepth 1 -type f -name '*.orig.*' \
+			-maxdepth 1 -type f \
+			'(' -name '*.orig.*' -o -name '*.orig-*.*' ')' \
 			-exec ln -s '{}' ./ ';'
 
 		/usr/bin/build-and-provide-package


### PR DESCRIPTION
Well, silly me. The part I touched "correctly" moves, not link. The
linking is the second find, and I didn't fix it. So, fix it in this
commit, and also revert the comment change.

🤦

Fixes: efe9052f ("build-binary: fix finding multiple orig tarballs")