### PR TITLE
BaPDP: add main and ubports/latest to productionBranches

### DIFF
--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -3,7 +3,7 @@ def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
   String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
   long telegramChatId = -1001480273427
   def productionBranches = [
-    'master',
+    'master', 'main', 'ubports/latest'
     'xenial', 'ubports/xenial',
     'xenial_-_android9', 'ubports/xenial_-_android9',
     'ubports/xenial_-_edge', 'xenial_-_edge',

--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -2,7 +2,13 @@ def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
   String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
   String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
   long telegramChatId = -1001480273427
-  def productionBranches = ['xenial', 'master', 'ubports/xenial', 'ubports/xenial_-_android9', 'ubports/xenial_-_edge', 'xenial_-_android9', 'xenial_-_edge', 'xenial_-_edge_-_android9', 'xenial_-_edge_-_pine', 'xenial_-_edge_-_wayland']
+  def productionBranches = [
+    'master',
+    'xenial', 'ubports/xenial',
+    'xenial_-_android9', 'ubports/xenial_-_android9',
+    'ubports/xenial_-_edge', 'xenial_-_edge',
+    'xenial_-_edge_-_android9', 'xenial_-_edge_-_pine', 'xenial_-_edge_-_wayland'
+  ]
   pipeline {
     agent none
     options {


### PR DESCRIPTION
main and ubports/latest is what ships in Focal. On some repos, it even
ships to Xenial. Thus, it should be qualified as "production" and we
should be notified of failure.