### PR TITLE
BaPDP: factor out notifyTelegram and the post steps to separated files

### DIFF
--- a/vars/notifyBuildStatus.groovy
+++ b/vars/notifyBuildStatus.groovy
@@ -1,0 +1,36 @@
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+def call(
+  RunWrapper currentBuild,
+  String jobDescription,
+  String jobUrl
+) {
+  String status;
+  Boolean needUrl = false;
+
+  switch (currentBuild.currentResult) {
+    case "SUCCESS":
+      if (currentBuild?.getPreviousBuild()?.resultIsWorseOrEqualTo("UNSTABLE"))
+        status = "**FIXED**";
+      else
+        status = "**SUCCESS**";
+
+      break;
+
+    case "UNSTABLE":
+      status = "**UNSTABLE**";
+      needUrl = true;
+      break;
+
+    case "FAILURE":
+      if (currentBuild?.getPreviousBuild()?.resultIsWorseOrEqualTo("FAILURE"))
+        status = "**NOT FIXED**";
+      else
+        status = "**FAILURE**";
+
+      needUrl = true;
+      break;
+  }
+
+  notifyTelegram("${jobDescription}: ${status}${needUrl ? ", check ${jobUrl}" : ""}");
+}

--- a/vars/notifyTelegram.groovy
+++ b/vars/notifyTelegram.groovy
@@ -1,0 +1,6 @@
+def call(String message) {
+  withCredentials([usernamePassword(credentialsId: 'a25d8b20-4a81-43e9-ac37-dcfb5285790a', usernameVariable: 'TELEGRAM_BOT_CREDS_USR', passwordVariable: 'TELEGRAM_BOT_CREDS_PWD')]) {
+    env['TELEGRAM_BOT_MSG'] = message
+    sh('curl -s -X POST https://api.telegram.org/$TELEGRAM_BOT_CREDS_PWD/sendMessage -d chat_id=$TELEGRAM_BOT_CREDS_USR -d text="$TELEGRAM_BOT_MSG"')
+  }
+}


### PR DESCRIPTION
This enables the notification code to be reused by non-Deb projects e.g.
rootfs-builder-debos.