### PR TITLE
BaPDP: add argument isHeavyPackage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,20 @@
 @Library('ubports-build-tools') _
 
-buildAndProvideDebianPackage()
+/*
+ * Arguments of buildAndProvideDebianPackage():
+ * - isArchIndependent: a hint that this package contains only 'Architecture:
+ *   all' package(s), and thus Jenkins doesn't have to dispatch build to nodes
+ *   of every architecture. Note that this will confuse BlueOcean UI, causing it
+ *   to not show any progress during the 'Build binary' step. However, if
+ *   needed, one can still track the progress on the classic UI.
+ * - ignoredArches: a list of architectures where the package should not be
+ *   built. For example, [ 'armhf' ].
+ * - isHeavyPackage: a hint that this package requires a significantly more
+ *   resource to build, and would benefit from building on faster nodes.
+ */
 
-// Or if the package consists entirely of arch-independent packages:
-// (optional optimization, will confuse BlueOcean's live view at build stage)
-// buildAndProvideDebianPackage(/* isArchIndependent */ true)
-
-// Optionally, to skip building on some architectures (amd64 is always built):
-// buildAndProvideDebianPackage(false, /* ignoredArchs */ ['arm64'])
+buildAndProvideDebianPackage(
+    /* isArchIndependent */ false,
+    /* ignoredArchs */ [],
+    /* isHeavyPackage */ false
+)

--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -1,4 +1,8 @@
-def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
+def call(
+    Boolean isArchIndependent = false,
+    List ignoredArchs = [],
+    Boolean isHeavyPackage = false)
+{
   String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
   String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
   def productionBranches = [
@@ -34,7 +38,7 @@ def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
       stage('Build binaries') {
         parallel {
           stage('Build binary - armhf') {
-            agent { label 'armhf' }
+            agent { label (isHeavyPackage ? 'armhf-fast' : 'armhf') }
             when { expression { return !isArchIndependent && !ignoredArchs.contains('armhf') } }
             steps {
               deleteDir()
@@ -49,7 +53,7 @@ def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
             }
           }
           stage('Build binary - arm64') {
-            agent { label 'arm64' }
+            agent { label (isHeavyPackage ? 'arm64-fast' : 'arm64') }
             when { expression { return !isArchIndependent && !ignoredArchs.contains('arm64') } }
             steps {
               deleteDir()
@@ -64,7 +68,7 @@ def call(Boolean isArchIndependent = false, List ignoredArchs = []) {
             }
           }
           stage('Build binary - amd64') {
-            agent { label 'amd64' }
+            agent { label (isHeavyPackage ? 'amd64-fast' : 'amd64') }
             // Always run; arch-independent packages are built here.
             steps {
               deleteDir()


### PR DESCRIPTION
This argument is a hint that this package requires a significantly more
resource to build, and would benefit from building on faster nodes.

This is intended for packages like QtWebEngine which takes a lot of time to compile.