### PR TITLE
Revert freight_wrapper back to upstream

### DIFF
--- a/build-and-provide-package
+++ b/build-and-provide-package
@@ -963,20 +963,11 @@ freight_wrapper() {
   freight_ensure_repo
 
   echo "*** Including packages via freight in repository ${FREIGHT_VARLIB}/${REPOS} ***"
-  ${SUDO_CMD:-} freight add -v -c "$FREIGHT_CONF" "${WORKSPACE}/binaries/"*"deb" "apt/${REPOS}"
+  ${SUDO_CMD:-} freight add -v -c "$FREIGHT_CONF" "${WORKSPACE}/binaries/"*"_${newest_version}"*"deb" "apt/${REPOS}"
   [ $? -eq 0 ] || bailout 1 "Error: Failed to add binary package to repository."
-  echo "*** Including any source packages we also need in repository ${FREIGHT_VARLIB}/${REPOS} ***"
-  for ext in xz gz dsc; do
-    for i in ${WORKSPACE}/binaries/*.${ext}; do
-        [ -f "$i" ] || break
-        ${SUDO_CMD:-} freight add -v -c "$FREIGHT_CONF" "$i" "apt/${REPOS}"
-    done
-  done
 
   echo "*** Generating freight cache ***"
-  if [ -z "${SHIP_FREIGHT_CACHE:-}" ] ; then
-     ${SUDO_CMD:-} freight cache -v -c "$FREIGHT_CONF" "apt/${REPOS}"
-  fi
+  ${SUDO_CMD:-} freight cache -v -c "$FREIGHT_CONF"
   [ $? -eq 0 ] || bailout 1 "Error: Failed to generate freight cache for ${FREIGHT_VARCACHE}."
 }
 


### PR DESCRIPTION
Since we don't use freight anymore, let's revert this back to upstream and reduce the diff.

I do this in git to keep the history.