### PR TITLE
build-source & vars: Build ubports/contrib similarly to ubports/latest

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -47,7 +47,7 @@ pr_repo_naming() {
 }
 
 # Multi distro, set here to build master for multripple distros!
-MULTIDIST_BRANCHES="main master ubports/latest"
+MULTIDIST_BRANCHES="main master ubports/latest ubports/contrib"
 # Contains the distribution name and versioning suffix
 BUILD_DISTS_MULTI="\
 focal ubports20.04

--- a/vars/buildAndProvideDebianPackage.groovy
+++ b/vars/buildAndProvideDebianPackage.groovy
@@ -6,7 +6,7 @@ def call(
   String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
   String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
   def productionBranches = [
-    'master', 'main', 'ubports/latest',
+    'master', 'main', 'ubports/latest', 'ubports/contrib',
     'xenial', 'ubports/xenial',
     'xenial_-_android9', 'ubports/xenial_-_android9',
     'ubports/xenial_-_edge', 'xenial_-_edge',


### PR DESCRIPTION
Treat ubports/contrib branches similarly to /latest when building since these are supposed to be incubation projects for upstreaming purposes.